### PR TITLE
Fix GCP deploy authentication for App Engine

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Authenticate to Google Cloud
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
       - name: Deploy to App Engine
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: google-github-actions/deploy-appengine@v2
@@ -36,4 +42,3 @@ jobs:
           deliverables: app.yaml
           version: v1
           project_id: ${{ secrets.GCP_PROJECT }}
-          credentials: ${{ secrets.GCP_CREDENTIALS }}


### PR DESCRIPTION
## Summary
- `deploy-appengine@v2` no longer supports the inline `credentials` parameter
- Add a separate `google-github-actions/auth@v2` step to authenticate with the service account key stored in `GCP_CREDENTIALS` before deploying
- This fixes the "You do not currently have an active account selected" error on deploy

## Test plan
- [ ] Merge and verify deploy to App Engine succeeds
- [ ] Confirm ubeshi.com serves the updated build