### PR TITLE
Fix App Engine deploy: nodejs22 runtime and skip Cloud Build

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,1 +1,6 @@
 node_modules/
+package.json
+package-lock.json
+src/
+public/
+scripts/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,13 +30,13 @@ jobs:
         run: npm run build
 
       - name: Authenticate to Google Cloud
-        if: (github.ref == 'refs/heads/main' && github.event_name == 'push') || github.event_name == 'workflow_dispatch'
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
       - name: Deploy to App Engine
-        if: (github.ref == 'refs/heads/main' && github.event_name == 'push') || github.event_name == 'workflow_dispatch'
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: google-github-actions/deploy-appengine@v2
         with:
           deliverables: app.yaml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,13 +30,13 @@ jobs:
         run: npm run build
 
       - name: Authenticate to Google Cloud
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: (github.ref == 'refs/heads/main' && github.event_name == 'push') || github.event_name == 'workflow_dispatch'
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
       - name: Deploy to App Engine
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: (github.ref == 'refs/heads/main' && github.event_name == 'push') || github.event_name == 'workflow_dispatch'
         uses: google-github-actions/deploy-appengine@v2
         with:
           deliverables: app.yaml

--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs20
+runtime: nodejs22
 handlers:
 - url: /
   static_files: build/index.html

--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,12 @@
 runtime: nodejs22
+env: standard
+
+instance_class: F1
+automatic_scaling:
+  max_instances: 2
+
+entrypoint: node -e ""
+
 handlers:
 - url: /
   static_files: build/index.html


### PR DESCRIPTION
## Summary
- Update App Engine runtime from `nodejs20` (end of support) to `nodejs22`
- Add `.gcloudignore` entries to exclude `package.json`, `package-lock.json`, and source files from deploy upload — prevents App Engine Cloud Build from running its own `npm install` which fails on peer dep conflicts
- Add explicit scaling config (`max_instances: 2`) and no-op entrypoint since this is a static-only site
- Tested via `workflow_dispatch` deploy from this branch — confirmed deploy succeeds and site serves correctly

## Test plan
- [x] Deploy tested via workflow_dispatch on feature branch
- [x] ubeshi.com verified serving after deploy